### PR TITLE
Added hapi-plugin-oracledb to list of plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -413,6 +413,10 @@ exports.categories = {
             url: 'https://github.com/christophercliff/hapi-nudge',
             description: 'A Hapi plugin to prevent Heroku dynos from sleeping'
         },
+        'hapi-plugin-oracledb': {
+            url: 'https://github.com/tejzpr/hapi-plugin-oracledb',
+            description: 'An Oracle database connection and configuration plugin with connection pooling via node-oracledb'
+        },
         hapio: {
             url: 'https://github.com/caligone/hapio',
             description: 'A simple bridge plugin between HapiJS and SocketIO'


### PR DESCRIPTION
Hi Hapi People!
Just adding my node-oracledb wrapper for Hapijs https://www.npmjs.com/package/hapi-plugin-oracledb to the list of plugins. Thanks!